### PR TITLE
Rename dark70p_60f to dark720p_60f

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -207,7 +207,7 @@
         "wikipedia_420.y4m"
       ],
       "720p": [
-        "dark70p_60f.y4m",
+        "dark720p_60f.y4m",
         "gipsrestat720p_60f.y4m",
         "vidyo1_720p_60fps_60f.y4m",
         "vidyo4_720p_60fps_60f.y4m",
@@ -229,7 +229,7 @@
     "sources": [
       "aspen_1080p_60f.y4m",
       "blue_sky_360p_60f.y4m",
-      "dark70p_60f.y4m",
+      "dark720p_60f.y4m",
       "DOTA2_60f_420.y4m",
       "ducks_take_off_1080p50_60f.y4m",
       "gipsrestat720p_60f.y4m",


### PR DESCRIPTION
There is an error in the name, which can be confusing.
In the current version of objective-1-fast, the file name is
the correct one, so deploying AWCY and running on this
set will generate errors unless the file is renamed.

With this change the AWCY back-end will need to have its files renamed in the affected sets.