### PR TITLE
Use decoder output (dav1d or aomdec) for rav1e BD rate computation and assert that it is equal to reconstruction output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ Node dependencies
 
 Individual build machines do not need Python, but do need bash. Each machine
 should be configured with a user and work_root (such as that user's home
-directory). This work directory must be populated with a folder called
-daalatool and dump\_ciede2000, which needs to contain a checkout of Daala
-and dump\_ciede git with the tools built:
+directory). This work directory must be populated with folders called
+daalatool, dump\_ciede2000, and dav1d, which need to contain checkouts of
+Daala, dump\_ciede and dav1d git repositories, each with tools built.
+
+To compile Daala tools:
 
 ```
 sudo apt install autoconf libogg-dev libjpeg-dev libpng-dev check python3-numpy python3-scipy
@@ -36,11 +38,21 @@ cd daalatool
 make tools -j4
 ```
 
-For dump\_ciede2000, exit the daalatool directory
+For dav1d:
 
 ```
-cd ../
+sudo apt install meson
 ```
+
+```
+git clone https://code.videolan.org/videolan/dav1d.git
+cd dav1d
+mkdir build && cd build
+meson ..
+ninja
+```
+
+For dump\_ciede2000:
 
 Install rust if you haven't already. You only need rust to compile the binary
 and don't need it on the individual machines.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Node dependencies
 Individual build machines do not need Python, but do need bash. Each machine
 should be configured with a user and work_root (such as that user's home
 directory). This work directory must be populated with folders called
-daalatool, dump\_ciede2000, and dav1d, which need to contain checkouts of
-Daala, dump\_ciede and dav1d git repositories, each with tools built.
+daalatool, dump\_ciede2000, and, optionally, dav1d and vmaf, which need to
+contain checkouts of their respective git repositories, each with tools built.
 
 To compile Daala tools:
 
@@ -36,20 +36,6 @@ cd daalatool
 ./autogen.sh
 ./configure --disable-player
 make tools -j4
-```
-
-For dav1d:
-
-```
-sudo apt install meson
-```
-
-```
-git clone https://code.videolan.org/videolan/dav1d.git
-cd dav1d
-mkdir build && cd build
-meson ..
-ninja
 ```
 
 For dump\_ciede2000:
@@ -75,7 +61,21 @@ Exit that directory
 cd ../
 ```
 
-Checkout and build vmaf (Optional)
+For dav1d (optional):
+
+```
+sudo apt install meson
+```
+
+```
+git clone https://code.videolan.org/videolan/dav1d.git
+cd dav1d
+mkdir build && cd build
+meson ..
+ninja
+```
+
+For vmaf (optional):
 
 ```
 git clone https://github.com/Netflix/vmaf.git

--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -93,6 +93,10 @@ if [ -z "$YUV2YUV4MPEG" ]; then
   export YUV2YUV4MPEG="$DAALATOOL_ROOT/tools/yuv2yuv4mpeg"
 fi
 
+if [ -z "$DAV1D" ]; then
+  export DAV1D="$DAALATOOL_ROOT/../dav1d/build/tools/dav1d"
+fi
+
 if [ -z "$CODEC" ]; then
   export CODEC=daala
 fi
@@ -222,7 +226,8 @@ thor-rt)
   SIZE=$(stat -c %s $BASENAME.thor)
   ;;
 rav1e)
-  $($TIMER $RAV1E $FILE --quantizer $x -o $BASENAME.ivf -r $BASENAME.y4m --threads 1 $EXTRA_OPTIONS > $BASENAME-enc.out)
+  $($TIMER $RAV1E $FILE --quantizer $x -o $BASENAME.ivf -r $BASENAME-rec.y4m --threads 1 $EXTRA_OPTIONS > $BASENAME-enc.out)
+  $DAV1D -i $BASENAME.ivf -o $BASENAME.y4m
   SIZE=$(stat -c %s $BASENAME.ivf)
   ;;
 svt-av1)
@@ -315,8 +320,3 @@ if [ ! "$NO_DELETE" ]; then
 fi
 
 rm -f pid
-
-
-
-
-

--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -227,7 +227,11 @@ thor-rt)
   ;;
 rav1e)
   $($TIMER $RAV1E $FILE --quantizer $x -o $BASENAME.ivf -r $BASENAME-rec.y4m --threads 1 $EXTRA_OPTIONS > $BASENAME-enc.out)
-  $DAV1D -i $BASENAME.ivf -o $BASENAME.y4m
+  if [ -f "$DAV1D" ]; then
+    $($TIMERDEC $DAV1D -i $BASENAME.ivf -o $BASENAME.y4m)
+  else
+    $($TIMERDEC $AOMDEC --codec=av1 $AOMDEC_OPTS -o $BASENAME.y4m $BASENAME.ivf)
+  fi
   SIZE=$(stat -c %s $BASENAME.ivf)
   ;;
 svt-av1)

--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -232,6 +232,9 @@ rav1e)
   else
     $($TIMERDEC $AOMDEC --codec=av1 $AOMDEC_OPTS -o $BASENAME.y4m $BASENAME.ivf)
   fi
+  "$Y4M2YUV" "$BASENAME-rec.y4m" -o rec.yuv
+  "$Y4M2YUV" "$BASENAME.y4m" -o enc.yuv
+  cmp --silent rec.yuv enc.yuv || (echo "Reconstruction differs from output!"; exit 1)
   SIZE=$(stat -c %s $BASENAME.ivf)
   ;;
 svt-av1)
@@ -302,8 +305,8 @@ if [ -f "$VMAFOSSEXEC" ]; then
           FORMAT=yuv444p
           ;;
   esac
-  "$DAALATOOL_ROOT/tools/y4m2yuv" "$FILE" -o ref
-  "$DAALATOOL_ROOT/tools/y4m2yuv" "$BASENAME.y4m" -o dis
+  "$Y4M2YUV" "$FILE" -o ref
+  "$Y4M2YUV" "$BASENAME.y4m" -o dis
   VMAF=$("$VMAFOSSEXEC" $FORMAT $WIDTH $HEIGHT ref dis "$VMAF_ROOT/model/vmaf_v0.6.1.pkl" --thread 1 | tail -n 1)
   rm -f ref dis
   echo "$VMAF"


### PR DESCRIPTION
If dav1d is missing, fall back to `aomdec`. This replaces the current method of comparing with the encoder reconstruction.