### PR TITLE
Make dav1d decode quietly

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -228,7 +228,7 @@ thor-rt)
 rav1e)
   $($TIMER $RAV1E $FILE --quantizer $x -o $BASENAME.ivf -r $BASENAME-rec.y4m --threads 1 $EXTRA_OPTIONS > $BASENAME-enc.out)
   if [ -f "$DAV1D" ]; then
-    $($TIMERDEC $DAV1D -i $BASENAME.ivf -o $BASENAME.y4m)
+    $($TIMERDEC $DAV1D -q -i $BASENAME.ivf -o $BASENAME.y4m)
   else
     $($TIMERDEC $AOMDEC --codec=av1 $AOMDEC_OPTS -o $BASENAME.y4m $BASENAME.ivf)
   fi


### PR DESCRIPTION
Without this, every decoded frame will generate
an extra line of output in case of a desync.