### PR TITLE
Revert "Return a no-retry exit code on rav1e decode errors (#53)"

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -228,13 +228,13 @@ thor-rt)
 rav1e)
   $($TIMER $RAV1E $FILE --quantizer $x -o $BASENAME.ivf -r $BASENAME-rec.y4m --threads 1 $EXTRA_OPTIONS > $BASENAME-enc.out)
   if [ -f "$DAV1D" ]; then
-    $($TIMERDEC $DAV1D -q -i $BASENAME.ivf -o $BASENAME.y4m) || (echo "Corrupt bitstream detected!"; exit 98)
+    $($TIMERDEC $DAV1D -q -i $BASENAME.ivf -o $BASENAME.y4m)
   else
-    $($TIMERDEC $AOMDEC --codec=av1 $AOMDEC_OPTS -o $BASENAME.y4m $BASENAME.ivf) || (echo "Corrupt bitstream detected!"; exit 98)
+    $($TIMERDEC $AOMDEC --codec=av1 $AOMDEC_OPTS -o $BASENAME.y4m $BASENAME.ivf)
   fi
   "$Y4M2YUV" "$BASENAME-rec.y4m" -o rec.yuv
   "$Y4M2YUV" "$BASENAME.y4m" -o enc.yuv
-  cmp --silent rec.yuv enc.yuv || (echo "Reconstruction differs from output!"; exit 98)
+  cmp --silent rec.yuv enc.yuv || (echo "Reconstruction differs from output!"; exit 1)
   SIZE=$(stat -c %s $BASENAME.ivf)
   ;;
 svt-av1)

--- a/rd_server.py
+++ b/rd_server.py
@@ -322,7 +322,7 @@ def scheduler_tick():
                     rd_print('Failed to write results for work item',slot.work.get_name())
                 work_done.append(slot.work)
                 rd_print(slot.work.log,slot.work.get_name(),'finished.')
-            elif slot.work.retries < max_retries and not slot.work.run.cancelled and slot.p.returncode != 98:
+            elif slot.work.retries < max_retries and not slot.work.run.cancelled:
                 slot.work.retries += 1
                 rd_print(slot.work.log,'Retrying work ',slot.work.get_name(),'...',slot.work.retries,'of',max_retries,'retries.')
                 slot.work.failed = False


### PR DESCRIPTION
Though I thought I had tested it properly it seems to cause runtime errors. I will submit a new PR to implement that functionality, tested more thoroughly.