### PR TITLE
Use installed decoders to test rav1e bitstream

### DIFF
--- a/rd_server.py
+++ b/rd_server.py
@@ -322,7 +322,7 @@ def scheduler_tick():
                     rd_print('Failed to write results for work item',slot.work.get_name())
                 work_done.append(slot.work)
                 rd_print(slot.work.log,slot.work.get_name(),'finished.')
-            elif slot.work.retries < max_retries and not slot.work.run.cancelled:
+            elif slot.work.retries < max_retries and not slot.work.run.cancelled and not slot.p.returncode == 98:
                 slot.work.retries += 1
                 rd_print(slot.work.log,'Retrying work ',slot.work.get_name(),'...',slot.work.retries,'of',max_retries,'retries.')
                 slot.work.failed = False


### PR DESCRIPTION
The decoders are now optional dependencies.
In case no decoder is installed, bitstream
testing will be skipped, and a message will
be logged.

Tested on my instance with both a working and a broken commit, seems to work as intended.

I'm not actually sure why it was failing before. It may not have been due to the return code patch.