### PR TITLE
Update and fix issues in VMAF implementation

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -86,7 +86,7 @@ if [ -z "$VMAF_ROOT" ]; then
 fi
 
 if [ -z "$VMAFOSSEXEC" ]; then
-  export VMAFOSSEXEC="$VMAF_ROOT/wrapper/vmafossexec"
+  export VMAFOSSEXEC="$VMAF_ROOT/libvmaf/build/tools/vmafossexec"
 fi
 
 if [ -z "$YUV2YUV4MPEG" ]; then
@@ -309,9 +309,10 @@ if [ -f "$VMAFOSSEXEC" ]; then
   esac
   "$Y4M2YUV" "$FILE" -o ref
   "$Y4M2YUV" "$BASENAME.y4m" -o dis
-  VMAF=$("$VMAFOSSEXEC" $FORMAT $WIDTH $HEIGHT ref dis "$VMAF_ROOT/model/vmaf_v0.6.1.pkl" --thread 1 | tail -n 1)
+  "$VMAFOSSEXEC" $FORMAT $WIDTH $HEIGHT ref dis "$VMAF_ROOT/model/vmaf_v0.6.1.pkl" --log-fmt csv --log "$BASENAME-vmaf.csv" --thread 1 | tail -n 1
+  VMAF=$(cat "$BASENAME-vmaf.csv" | grep -o "[^,]*" | tail -1)
   rm -f ref dis
-  echo "$VMAF"
+  echo "0 0 0 $VMAF"
 else
   echo 0 0 0 0
 fi

--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -298,7 +298,7 @@ if [ -f "$VMAFOSSEXEC" ]; then
   FORMAT=yuv420p
   case $CHROMA in
       420p10)
-          FORMAT=yuv444p10le
+          FORMAT=yuv420p10le
           ;;
       444p10)
           FORMAT=yuv444p10le

--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -312,9 +312,9 @@ if [ -f "$VMAFOSSEXEC" ]; then
   "$VMAFOSSEXEC" $FORMAT $WIDTH $HEIGHT ref dis "$VMAF_ROOT/model/vmaf_v0.6.1.pkl" --log-fmt csv --log "$BASENAME-vmaf.csv" --thread 1 | tail -n 1
   VMAF=$(cat "$BASENAME-vmaf.csv" | grep -o "[^,]*" | tail -1)
   rm -f ref dis
-  echo "0 0 0 $VMAF"
+  echo "$VMAF"
 else
-  echo 0 0 0 0
+  echo "0"
 fi
 
 if [ -e "$TIMERDECOUT" ]; then

--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -89,6 +89,10 @@ if [ -z "$VMAFOSSEXEC" ]; then
   export VMAFOSSEXEC="$VMAF_ROOT/libvmaf/build/tools/vmafossexec"
 fi
 
+if [ -z "$VMAFMODEL" ]; then
+  export VMAFMODEL="vmaf_v0.6.1.pkl" # File name in $VMAFROOT/model
+fi
+
 if [ -z "$YUV2YUV4MPEG" ]; then
   export YUV2YUV4MPEG="$DAALATOOL_ROOT/tools/yuv2yuv4mpeg"
 fi
@@ -309,7 +313,7 @@ if [ -f "$VMAFOSSEXEC" ]; then
   esac
   "$Y4M2YUV" "$FILE" -o ref
   "$Y4M2YUV" "$BASENAME.y4m" -o dis
-  "$VMAFOSSEXEC" $FORMAT $WIDTH $HEIGHT ref dis "$VMAF_ROOT/model/vmaf_v0.6.1.pkl" --log-fmt csv --log "$BASENAME-vmaf.csv" --thread 1 | tail -n 1
+  "$VMAFOSSEXEC" $FORMAT $WIDTH $HEIGHT ref dis "$VMAF_ROOT/model/$VMAFMODEL" --log-fmt csv --log "$BASENAME-vmaf.csv" --thread 1 | tail -n 1
   VMAF=$(cat "$BASENAME-vmaf.csv" | grep -o "[^,]*" | tail -1)
   rm -f ref dis
   echo "$VMAF"

--- a/work.py
+++ b/work.py
@@ -136,8 +136,8 @@ class RDWork(Work):
             self.metric['msssim'][1] = split[50]
             self.metric['msssim'][2] = split[52]
             self.metric['encodetime'] = split[53]
-            self.metric['vmaf'] = split[57]
-            self.metric['decodetime'] = split[58]
+            self.metric['vmaf'] = split[54]
+            self.metric['decodetime'] = split[55]
             self.failed = False
         except IndexError:
             rd_print(self.log,'Decoding result for '+self.filename+' at quality '+str(self.quality)+' failed!')


### PR DESCRIPTION
* Fix the format set for 10-bit 4:2:0
* Update the default $VMAFOSSEXEC path
* Update the VMAF command line
* Fix VMAF extraction expecting garbage preceding the score
* Parameterize the VMAF model name