### PR TITLE
Reverse free_slots order for initial machine list.

### DIFF
--- a/rd_server.py
+++ b/rd_server.py
@@ -217,7 +217,7 @@ def main():
             machines.append(sshslot.Machine(m['host'],m['user'],m['cores'],m['work_root'],str(m['port']),m['media_path']))
         for machine in machines:
             slots.extend(machine.get_slots())
-        free_slots.extend(slots)
+        free_slots.extend(reversed(slots))
     app = tornado.web.Application(
         [
             (r"/work_list.json", WorkListHandler),


### PR DESCRIPTION
The free_slots array is used as a stack, this patch reverses the order
 so machine slots are filled in lexicographic order on AWCY restart.