### PR TITLE
Update thte still image test sets to match AV2 CTC.

### DIFF
--- a/sets.json
+++ b/sets.json
@@ -119,8 +119,7 @@
       "landscape_26.y4m",
       "landscape_28.y4m",
       "snow_00.y4m",
-      "underwater_01.y4m",
-      "Matinkaaren_silta.y4m"
+      "underwater_01.y4m"
     ]
   },
   "av2-f2-midres": {
@@ -153,7 +152,6 @@
       "Esquibien_Jean_Perrot.y4m",
       "Genmaicha_Tea.y4m",
       "Homestead_in_Montana.y4m",
-      "KellermanBallfieldMefisto.y4m",
       "Madeira_151_Funchal_Mercado_dos_Lavradores.y4m",
       "OperaLamps.y4m"
     ]


### PR DESCRIPTION
Remove Matinkaaren_silta.y4m and KellermanBallfieldMefisto.y4m images
 from av2-f1-hires and av2-f2-midres test sets respectively.