### PR TITLE
Remove shellquotes call from scp parameter

### DIFF
--- a/sshslot.py
+++ b/sshslot.py
@@ -154,7 +154,7 @@ class Slot:
         kill_thread.daemon = True
         kill_thread.start()
     def get_file(self, remote, local):
-        return subprocess.call(['scp','-i',ssh_privkey_file,'-P',self.machine.port,self.machine.user+'@'+self.machine.host+':'+shellquote(remote),local])
+        return subprocess.call(['scp','-i',ssh_privkey_file,'-P',self.machine.port,self.machine.user+'@'+self.machine.host+':'+remote,local])
     def check_shell(self, command):
         return subprocess.check_output(['ssh','-i',ssh_privkey_file,'-p',self.machine.port,'-o',' StrictHostKeyChecking=no',
            self.machine.user+'@'+self.machine.host,


### PR DESCRIPTION
There is no shell parsing, so shellquotes shouldn't be needed for
this command.

With some versions of scp, passing quotes to the actual executable (as
opposed to a parsed shell command) results in failure without the -T
option.