### PR TITLE
Replace scp with rsync and remove quotes

### DIFF
--- a/sshslot.py
+++ b/sshslot.py
@@ -154,7 +154,7 @@ class Slot:
         kill_thread.daemon = True
         kill_thread.start()
     def get_file(self, remote, local):
-        return subprocess.call(['scp','-i',ssh_privkey_file,'-P',self.machine.port,self.machine.user+'@'+self.machine.host+':'+shellquote(remote),local])
+        return subprocess.call(['rsync', '-e', "ssh -i "+ssh_privkey_file+" -o StrictHostKeyChecking=no -p "+str(self.machine.port), self.machine.user+'@'+self.machine.host+':'+shellquote(remote), local])
     def check_shell(self, command):
         return subprocess.check_output(['ssh','-i',ssh_privkey_file,'-p',self.machine.port,'-o',' StrictHostKeyChecking=no',
            self.machine.user+'@'+self.machine.host,


### PR DESCRIPTION
We aren't parsing w/ a shell, so the quotes trigger errors related to
non-literal parsing in scp. Adding -T would fix these issues, but we
can switch to using rsync instead.

When rsync fails, it's more verbose than scp. Unfortunately,
metric_gather.sh does not currently produce all of the files that are
being requested for rav1e/other codecs. This means there is some amount
of spam produced in those logs.