### PR TITLE
reinstate -T, also disable StrictHostkeyChecking in get_file()

### DIFF
--- a/sshslot.py
+++ b/sshslot.py
@@ -154,7 +154,7 @@ class Slot:
         kill_thread.daemon = True
         kill_thread.start()
     def get_file(self, remote, local):
-        return subprocess.call(['scp','-i',ssh_privkey_file,'-P',self.machine.port,self.machine.user+'@'+self.machine.host+':'+shellquote(remote),local])
+        return subprocess.call(['scp','-T','-o',' StrictHostKeyChecking=no','-i',ssh_privkey_file,'-P',self.machine.port,self.machine.user+'@'+self.machine.host+':'+shellquote(remote),local])
     def check_shell(self, command):
         return subprocess.check_output(['ssh','-i',ssh_privkey_file,'-p',self.machine.port,'-o',' StrictHostKeyChecking=no',
            self.machine.user+'@'+self.machine.host,


### PR DESCRIPTION
Looks like this typo has always been there and folks were either renaming the file in the set, or the file in the set was misnamed back then too.  These days, the test sets up for download at xiph have the correct filename, and this caused a bit of a headscratcher for a while (because typos are hard to spot, especially when there's a second bug there that looks identical).