### PR TITLE
Update svt-av1 arguments

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -321,7 +321,7 @@ rav1e)
 svt-av1)
   export LD_LIBRARY_PATH=$(dirname "$SVTAV1")
   # svt-av1 has a max intra period of 255
-  $($TIMER $SVTAV1 -i $FILE -enc-mode 0 -lp 1 -q $x -o $BASENAME.yuv -b $BASENAME.ivf -w $WIDTH -h $HEIGHT -intra-period 255 $EXTRA_OPTIONS > $BASENAME-enc.out 2>&1)
+  $($TIMER $SVTAV1 -i $FILE --preset 0 --lp 1 -q $x -o $BASENAME.yuv -b $BASENAME.ivf -w $WIDTH -h $HEIGHT --intra-period 255 $EXTRA_OPTIONS > $BASENAME-enc.out 2>&1)
   $YUV2YUV4MPEG $BASENAME -an1 -ad1 -w$WIDTH -h$HEIGHT > /dev/null
   rm $BASENAME.yuv
   SIZE=$(stat -c %s $BASENAME.ivf)


### PR DESCRIPTION
Remove depreciated args so that new versions of svt-av1 can run.

Tested locally. Now all we need is to prevent svt-av1 from trying to
compile with emscripten's llvm on awcy.