### PR TITLE
Server: Fix Still Image Encoding and Tick tweaks

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -246,6 +246,10 @@ av2 | av2-ai | av2-ra | av2-ra-st | av2-ld | av2-as)
   case $CTC_CLASS in
     G1 | G2)
     CTC_PROFILE_OPTS+=" --color-primaries=bt2020 --transfer-characteristics=smpte2084 --matrix-coefficients=bt2020ncl --chroma-sample-position=colocated"
+    ;;
+    F1 | F2)
+    CTC_PROFILE_OPTS+=" --limit=1 "
+    ;;
   esac
   # threading options for the A1 test set must be overriden via EXTRA_OPTIONS at a higher level
   case $CODEC in

--- a/rd_server.py
+++ b/rd_server.py
@@ -411,15 +411,20 @@ def scheduler_tick():
         run_tracker[this_run] = {}
         run_tracker[this_run]['done'] = True
         run_tracker[this_run]['sets'] = {}
+        ## Part 1: Initialise flags as True
         for run in run_list:
             if run.runid == this_run:
                 run_tracker[this_run]['sets'][run.set] = True
+        ## Part 2: Update flags
         for run in run_list:
             if run.runid == this_run:
                 for work in run.work_items:
                     if work.done == False:
                         run_tracker[this_run]['sets'][run.set] = False
                         run_tracker[this_run]['done'] = False
+        ## Part 3: Send updates and curate results.
+        for run in run_list:
+            if run.runid == this_run:
                 if run_tracker[this_run]['sets'][run.set]:
                     rd_print(run.log, "Finished Encoding ", run.set, "set.")
                     run_list.remove(run)

--- a/rd_server.py
+++ b/rd_server.py
@@ -13,6 +13,7 @@ import awsremote
 import queue
 from work import *
 from utility import *
+from work import quality_presets
 
 config_dir = os.getenv("CONFIG_DIR", os.getcwd())
 runs_dst_dir = os.getenv("RUNS_DST_DIR", os.path.join(os.getcwd(), "../runs"))
@@ -140,6 +141,8 @@ class SubmitTask(SchedulerTask):
             run.rundir = config['runs'] + '/' + run_id
             run.log = log_file
             run.set = this_video_set
+            if this_video_set in ['aomctc-f1-hires','aomctc-f2-midres']:
+                run.quality = quality_presets['av2-f']
             rd_print(run.log, "Starting encoding of ", this_video_set)
             if 'arch' in info:
                 run.arch = info['arch']


### PR DESCRIPTION
This patchset contains two fixes, 
a) Fixes F1/F2 Class Encoding, this was not accounting
 - `--limit=1`
 - `av2-f` Quality, we change the Quality on the fly during creation of each RDRun for these specific sets, which is most optimal and fast way. 

b) Tick tweaks, so there is an edge case where some of the inital jobs in the list finishes before others, tick logs things multiple times but only compute total.out once, which is not correct, so we break the tick into 3 parts. 