### PR TITLE
sshslot: Copy only SVT-AV1 binary

### DIFF
--- a/sshslot.py
+++ b/sshslot.py
@@ -29,7 +29,7 @@ binaries = {
     'thor': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
     'thor-rt': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
     'rav1e': ['target/release/rav1e'],
-    'svt-av1': ['Bin/Release/SvtAv1EncApp', 'Bin/Release/libSvtAv1Enc.so.0']
+    'svt-av1': ['Bin/Release/SvtAv1EncApp']
 }
 
 # Finding files such as `this_(that)` requires `'` be placed on both


### PR DESCRIPTION
The AWCY started to build static builds of SVT-AV1