### PR TITLE
sshslot: Remove shell-quotes for filenames

### DIFF
--- a/sshslot.py
+++ b/sshslot.py
@@ -154,7 +154,7 @@ class Slot:
         kill_thread.daemon = True
         kill_thread.start()
     def get_file(self, remote, local):
-        return subprocess.call(['rsync', '-e', "ssh -i "+ssh_privkey_file+" -o StrictHostKeyChecking=no -p "+str(self.machine.port), self.machine.user+'@'+self.machine.host+':'+shellquote(remote), local])
+        return subprocess.call(['rsync', '-s', '-e', "ssh -i "+ssh_privkey_file+" -o StrictHostKeyChecking=no -p "+str(self.machine.port), self.machine.user+'@'+self.machine.host+':'+remote, local])
     def check_shell(self, command):
         return subprocess.check_output(['ssh','-i',ssh_privkey_file,'-p',self.machine.port,'-o',' StrictHostKeyChecking=no',
            self.machine.user+'@'+self.machine.host,


### PR DESCRIPTION
This is a specific-rsync issue where some files are not copied back, and adding protect-args to make sure the rsync/remote do not do weird file-handling,

Man-page:
> -s, --protect-args
> This option sends all filenames and most options to the remote rsync without allowing the remote shell to interpret them.