### PR TITLE
Add VVC-VTM support

### DIFF
--- a/cfg/vvc-vtm/encoder_intra_vtm.cfg
+++ b/cfg/vvc-vtm/encoder_intra_vtm.cfg
@@ -1,0 +1,120 @@
+#======== File I/O =====================
+BitstreamFile                 : str.bin
+ReconFile                     : rec.yuv
+
+#======== Profile ================
+Profile                       : auto
+
+#======== Unit definition ================
+MaxCUWidth                    : 64          # Maximum coding unit width in pixel
+MaxCUHeight                   : 64          # Maximum coding unit height in pixel
+
+#======== Coding Structure =============
+IntraPeriod                   : 1           # Period of I-Frame ( -1 = only first)
+DecodingRefreshType           : 1           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
+GOPSize                       : 1           # GOP Size (number of B slice = GOPSize-1)
+#        Type POC QPoffset QPfactor tcOffsetDiv2 betaOffsetDiv2  temporal_id #ref_pics_active #ref_pics reference pictures
+
+#=========== Motion Search =============
+FastSearch                    : 1           # 0:Full search  1:TZ search
+SearchRange                   : 64          # (0: Search range is a Full frame)
+HadamardME                    : 1           # Use of hadamard measure for fractional ME
+FEN                           : 1           # Fast encoder decision
+FDM                           : 1           # Fast Decision for Merge RD cost
+
+#======== Quantization =============
+QP                            : 32          # Quantization parameter(0-51)
+MaxDeltaQP                    : 0           # CU-based multi-QP optimization
+MaxCuDQPSubdiv                : 0           # Maximum subdiv for CU luma Qp adjustment
+DeltaQpRD                     : 0           # Slice-based multi-QP optimization
+RDOQ                          : 1           # RDOQ
+RDOQTS                        : 1           # RDOQ for transform skip
+
+#=========== Deblock Filter ============
+DeblockingFilterOffsetInPPS         : 1           # Dbl params: 0=varying params in SliceHeader, param = base_param + GOP_offset_param; 1 (default) =constant params in PPS, param = base_param)
+DeblockingFilterDisable             : 0           # Disable deblocking filter (0=Filter, 1=No Filter)
+DeblockingFilterBetaOffset_div2     : -2           # base_param: -12 ~ 12
+DeblockingFilterTcOffset_div2       : -5           # base_param: -12 ~ 12
+DeblockingFilterCbBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCbTcOffset_div2     : -5           # base_param: -12 ~ 12
+DeblockingFilterCrBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCrTcOffset_div2     : -5           # base_param: -12 ~ 12
+DeblockingFilterMetric        : 0           # blockiness metric (automatically configures deblocking parameters in bitstream). Applies slice-level loop filter offsets (DeblockingFilterOffsetInPPS and DeblockingFilterDisable must be 0)
+
+#=========== Misc. ============
+InternalBitDepth              : 10          # codec operating bit-depth
+
+#=========== Coding Tools =================
+SAO                           : 1           # Sample adaptive offset  (0: OFF, 1: ON)
+TransformSkip                 : 1           # Transform skipping (0: OFF, 1: ON)
+TransformSkipFast             : 1           # Fast Transform skipping (0: OFF, 1: ON)
+TransformSkipLog2MaxSize      : 5
+SAOLcuBoundary                : 0           # SAOLcuBoundary using non-deblocked pixels (0: OFF, 1: ON)
+
+#============ VTM settings ======================
+SEIDecodedPictureHash               : 0
+CbQpOffset                          : 0
+CrQpOffset                          : 0
+SameCQPTablesForAllChroma           : 1
+QpInValCb                           : 17 27 32 44
+QpOutValCb                          : 17 29 34 41
+TemporalSubsampleRatio              : 8
+
+ReWriteParamSets                    : 1
+#============ NEXT ====================
+
+# General
+CTUSize                      : 128
+LCTUFast                     : 1
+
+DualITree                    : 1      # separate partitioning of luma and chroma channels for I-slices
+MinQTLumaISlice              : 8
+MinQTChromaISliceInChromaSamples: 4      # minimum QT size in chroma samples for chroma separate tree
+MinQTNonISlice               : 8
+MaxMTTHierarchyDepth         : 3
+MaxMTTHierarchyDepthISliceL  : 3
+MaxMTTHierarchyDepthISliceC  : 3
+
+MTS                          : 1
+MTSIntraMaxCand              : 4
+MTSInterMaxCand              : 4
+SBT                          : 1
+LFNST                        : 1
+ISP                          : 1
+Affine                       : 1
+SbTMVP                       : 1
+MaxNumMergeCand              : 6
+LMChroma                     : 1      # use CCLM only
+DepQuant                     : 1
+IMV                          : 1
+ALF                          : 1
+IBC                          : 0      # turned off in CTC
+AllowDisFracMMVD             : 1
+AffineAmvr                   : 0
+LMCSEnable                   : 1      # LMCS: 0: disable, 1:enable
+LMCSSignalType               : 0      # Input signal type: 0:SDR, 1:HDR-PQ, 2:HDR-HLG
+LMCSUpdateCtrl               : 1      # LMCS model update control: 0:RA, 1:AI, 2:LDB/LDP
+LMCSOffset                   : 2      # chroma residual scaling offset
+MRL                          : 1
+MIP                          : 1
+JointCbCr                    : 1      # joint coding of chroma residuals (if available): 0: disable, 1: enable
+ChromaTS                     : 1
+
+# Fast tools
+PBIntraFast                  : 1
+ISPFast                      : 1
+FastMrg                      : 1
+AMaxBT                       : 1
+FastMIP                      : 1
+FastLFNST                    : 1
+
+# Encoder optimization tools
+AffineAmvrEncOpt             : 0
+ALFAllowPredefinedFilters    : 1
+ALFStrengthTargetLuma        : 1.0
+ALFStrengthTargetChroma      : 1.0
+CCALFStrengthTarget          : 1.0
+### DO NOT ADD ANYTHING BELOW THIS LINE ###
+### DO NOT DELETE THE EMPTY LINE BELOW ###
+
+

--- a/cfg/vvc-vtm/encoder_lowdelay_vtm.cfg
+++ b/cfg/vvc-vtm/encoder_lowdelay_vtm.cfg
@@ -1,0 +1,153 @@
+#======== File I/O =====================
+BitstreamFile                 : str.bin
+ReconFile                     : rec.yuv
+
+#======== Profile ================
+Profile                       : auto
+
+#======== Unit definition ================
+MaxCUWidth                    : 64          # Maximum coding unit width in pixel
+MaxCUHeight                   : 64          # Maximum coding unit height in pixel
+
+#======== Coding Structure =============
+IntraPeriod                   : -1          # Period of I-Frame ( -1 = only first)
+DecodingRefreshType           : 0           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
+GOPSize                       : 8           # GOP Size (number of B slice = GOPSize-1)
+
+IntraQPOffset                 : -1
+LambdaFromQpEnable            : 1           # see JCTVC-X0038 for suitable parameters for IntraQPOffset, QPoffset, QPOffsetModelOff, QPOffsetModelScale when enabled
+#        Type POC QPoffset QPOffsetModelOff QPOffsetModelScale CbQPoffset CrQPoffset QPfactor tcOffsetDiv2 betaOffsetDiv2 CbTcOffsetDiv2 CbBetaOffsetDiv2 CrTcOffsetDiv2 CrBetaOffsetDiv2 temporal_id #ref_pics_active_L0 #ref_pics_L0   reference_pictures_L0 #ref_pics_active_L1 #ref_pics_L1   reference_pictures_L1
+Frame1:    B   1   6       -6.5                      0.2450         0          0          1.0      0            0               0              0                0               0               0             4                4         1 9 17 25                    4                   4      1 3 5 33
+Frame2:    B   2   4       -6.5                      0.2590         0          0          1.0      0            0               0              0                0               0               0             4                4         1 2 10 18                    4                   4      1 2 4 26
+Frame3:    B   3   6       -6.5                      0.2450         0          0          1.0      0            0               0              0                0               0               0             4                4         1 3 11 19                    4                   4      1 3 5 27
+Frame4:    B   4   4       -6.5                      0.2590         0          0          1.0      0            0               0              0                0               0               0             4                4         1 4 12 20                    4                   4      1 2 4 28
+Frame5:    B   5   6       -6.5                      0.2450         0          0          1.0      0            0               0              0                0               0               0             4                4         1 5 13 21                    4                   4      1 3 5 29
+Frame6:    B   6   4       -6.5                      0.2590         0          0          1.0      0            0               0              0                0               0               0             4                4         1 6 14 22                    4                   4      1 2 6 30
+Frame7:    B   7   6       -6.5                      0.2450         0          0          1.0      0            0               0              0                0               0               0             4                4         1 7 15 23                    4                   4      1 3 7 31
+Frame8:    B   8   1        0.0                      0.0            0          0          1.0      0            0               0              0                0               0               0             4                4         1 8 16 24                    4                   4      1 2 4 32
+
+#=========== Motion Search =============
+FastSearch                    : 1           # 0:Full search  1:TZ search
+SearchRange                   : 64          # (0: Search range is a Full frame)
+BipredSearchRange             : 4           # Search range for bi-prediction refinement
+HadamardME                    : 1           # Use of hadamard measure for fractional ME
+FEN                           : 1           # Fast encoder decision
+FDM                           : 1           # Fast Decision for Merge RD cost
+
+#======== Quantization =============
+QP                            : 32          # Quantization parameter(0-51)
+MaxDeltaQP                    : 0           # CU-based multi-QP optimization
+MaxCuDQPSubdiv                : 0           # Maximum subdiv for CU luma Qp adjustment
+DeltaQpRD                     : 0           # Slice-based multi-QP optimization
+RDOQ                          : 1           # RDOQ
+RDOQTS                        : 1           # RDOQ for transform skip
+
+#=========== Deblock Filter ============
+DeblockingFilterOffsetInPPS         : 1           # Dbl params: 0=varying params in SliceHeader, param = base_param + GOP_offset_param; 1 (default) =constant params in PPS, param = base_param)
+DeblockingFilterDisable             : 0           # Disable deblocking filter (0=Filter, 1=No Filter)
+DeblockingFilterBetaOffset_div2     : -2           # base_param: -12 ~ 12
+DeblockingFilterTcOffset_div2       : 0           # base_param: -12 ~ 12
+DeblockingFilterCbBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCbTcOffset_div2     : 0           # base_param: -12 ~ 12
+DeblockingFilterCrBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCrTcOffset_div2     : 0           # base_param: -12 ~ 12
+DeblockingFilterMetric        : 0           # blockiness metric (automatically configures deblocking parameters in bitstream). Applies slice-level loop filter offsets (DeblockingFilterOffsetInPPS and DeblockingFilterDisable must be 0)
+
+#=========== Misc. ============
+InternalBitDepth              : 10          # codec operating bit-depth
+
+#=========== Coding Tools =================
+SAO                           : 1           # Sample adaptive offset  (0: OFF, 1: ON)
+TransformSkip                 : 1           # Transform skipping (0: OFF, 1: ON)
+TransformSkipFast             : 1           # Fast Transform skipping (0: OFF, 1: ON)
+TransformSkipLog2MaxSize      : 5
+SAOLcuBoundary                : 0           # SAOLcuBoundary using non-deblocked pixels (0: OFF, 1: ON)
+
+#=========== TemporalFilter =================
+TemporalFilter                : 1
+TemporalFilterPastRefs        : 4           # Number of past references for temporal prefilter
+TemporalFilterFutureRefs      : 0           # Number of future references for temporal prefilter
+TemporalFilterStrengthFrame8  : 0.2         # Enable filter at every 8th frame with strength
+
+#============ Rate Control ======================
+RateControl                         : 0                # Rate control: enable rate control
+TargetBitrate                       : 1000000          # Rate control: target bitrate, in bps
+KeepHierarchicalBit                 : 2                # Rate control: 0: equal bit allocation; 1: fixed ratio bit allocation; 2: adaptive ratio bit allocation
+LCULevelRateControl                 : 1                # Rate control: 1: LCU level RC; 0: picture level RC
+RCLCUSeparateModel                  : 1                # Rate control: use LCU level separate R-lambda model
+InitialQP                           : 0                # Rate control: initial QP
+RCForceIntraQP                      : 0                # Rate control: force intra QP to be equal to initial QP
+
+#============ VTM settings ======================
+SEIDecodedPictureHash               : 0
+CbQpOffset                          : 0
+CrQpOffset                          : 0
+SameCQPTablesForAllChroma           : 1
+QpInValCb                           : 17 22 34 42
+QpOutValCb                          : 17 23 35 39
+ReWriteParamSets                    : 1
+#============ NEXT ====================
+
+# General
+CTUSize                      : 128
+LCTUFast                     : 1
+
+DualITree                    : 1      # separate partitioning of luma and chroma channels for I-slices
+MinQTLumaISlice              : 8
+MinQTChromaISliceInChromaSamples: 4      # minimum QT size in chroma samples for chroma separate tree
+MinQTNonISlice               : 8
+MaxMTTHierarchyDepth         : 3
+MaxMTTHierarchyDepthISliceL  : 3
+MaxMTTHierarchyDepthISliceC  : 3
+
+MTS                          : 1
+MTSIntraMaxCand              : 3
+MTSInterMaxCand              : 4
+SBT                          : 1
+ISP                          : 1
+MMVD                         : 1
+Affine                       : 1
+SbTMVP                       : 1
+MaxNumMergeCand              : 6
+LMChroma                     : 1      # use CCLM only
+DepQuant                     : 1
+IMV                          : 1
+ALF                          : 1
+BCW                          : 1
+BcwFast                      : 1
+CIIP                         : 1
+Geo                          : 1
+IBC                          : 0      # turned off in CTC
+AllowDisFracMMVD             : 1
+AffineAmvr                   : 0
+LMCSEnable                   : 1      # LMCS: 0: disable, 1:enable
+LMCSSignalType               : 0      # Input signal type: 0:SDR, 1:HDR-PQ, 2:HDR-HLG
+LMCSUpdateCtrl               : 2      # LMCS model update control: 0:RA, 1:AI, 2:LDB/LDP
+LMCSOffset                   : 1      # chroma residual scaling offset
+MRL                          : 1
+MIP                          : 0
+JointCbCr                    : 1      # joint coding of chroma residuals (if available): 0: disable, 1: enable
+PROF                         : 1
+ChromaTS                     : 1
+
+# Fast tools
+PBIntraFast                  : 1
+ISPFast                      : 0
+FastMrg                      : 1
+AMaxBT                       : 1
+FastMIP                      : 0
+FastLocalDualTreeMode        : 2
+
+# Encoder optimization tools
+AffineAmvrEncOpt             : 0
+MmvdDisNum                   : 6
+ALFAllowPredefinedFilters    : 1
+ALFStrengthTargetLuma        : 1.0
+ALFStrengthTargetChroma      : 1.0
+CCALFStrengthTarget          : 1.0
+EncDbOpt                     : 1      # apply deblocking in RDO
+### DO NOT ADD ANYTHING BELOW THIS LINE ###
+### DO NOT DELETE THE EMPTY LINE BELOW ###
+
+
+

--- a/cfg/vvc-vtm/encoder_randomaccess_vtm.cfg
+++ b/cfg/vvc-vtm/encoder_randomaccess_vtm.cfg
@@ -1,0 +1,184 @@
+#======== File I/O =====================
+BitstreamFile                 : str.bin
+ReconFile                     : rec.yuv
+
+#======== Profile ================
+Profile                       : auto
+
+#======== Unit definition ================
+MaxCUWidth                    : 64          # Maximum coding unit width in pixel
+MaxCUHeight                   : 64          # Maximum coding unit height in pixel
+
+#======== Coding Structure =============
+IntraPeriod                   : 32          # Period of I-Frame ( -1 = only first)
+DecodingRefreshType           : 1           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
+GOPSize                       : 32          # GOP Size (number of B slice = GOPSize-1)
+
+IntraQPOffset                 : -3
+LambdaFromQpEnable            : 1           # see JCTVC-X0038 for suitable parameters for IntraQPOffset, QPoffset, QPOffsetModelOff, QPOffsetModelScale when enabled
+#        Type POC QPoffset QPOffsetModelOff QPOffsetModelScale CbQPoffset CrQPoffset QPfactor tcOffsetDiv2 betaOffsetDiv2 CbTcOffsetDiv2 CbBetaOffsetDiv2 CrTcOffsetDiv2 CrBetaOffsetDiv2 temporal_id #ref_pics_active_L0 #ref_pics_L0   reference_pictures_L0 #ref_pics_active_L1 #ref_pics_L1   reference_pictures_L1
+Frame1  : B   32  -1   0.0     0.0     0  0  1.0  0  0  0  0  0  0  0  2  5  32 64 48 40 36  1  2   32 48 
+Frame2  : B   16   0  -4.9309  0.2265  0  0  1.0  0  0  0  0  0  0  1  3  5  16 32 48 24 20  1  1  -16 
+Frame3  : B    8   1  -4.5000  0.1900  0  0  1.0  0  0  0  0  0  0  2  4  5   8 24 16 40 12  2  2  -8 -24 
+Frame4  : B    4   3  -5.4095  0.2571  0  0  1.0  0  0  0  0  0  0  3  3  3   4  8 20        3  3  -4 -12 -28 
+Frame5  : B    2   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  3  3   2  6 18        4  4  -2 -6 -14 -30 
+Frame6  : B    1   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  1  1   1              2  5  -1 -3 -7 -15 -31 
+Frame7  : B    3   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  2   1  3           2  4  -1 -5 -13 -29 
+Frame8  : B    6   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  3  3   2  4  6        3  3  -2 -10 -26 
+Frame9  : B    5   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  2   1  5           2  4  -1 -3 -11 -27 
+Frame10 : B    7   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  3  7        2  3  -1 -9 -25 
+Frame11 : B   12   3  -5.4095  0.2571  0  0  1.0  0  0  0  0  0  0  3  3  4   4  8 12  6     2  2  -4 -20 
+Frame12 : B   10   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  4  4   2  4  6 10     3  3  -2 -6 -22 
+Frame13 : B    9   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  5  9        2  4  -1 -3 -7 -23 
+Frame14 : B   11   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  3 11        2  3  -1 -5 -21 
+Frame15 : B   14   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  4  4   2  4  6 14     2  2  -2 -18 
+Frame16 : B   13   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  5 13        2  3  -1 -3 -19 
+Frame17 : B   15   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  4   1  3  7 15     2  2  -1 -17 
+Frame18 : B   24   1  -4.5000  0.1900  0  0  1.0  0  0  0  0  0  0  2  3  3   8 16 24        1  1  -8
+Frame19 : B   20   3  -5.4095  0.2571  0  0  1.0  0  0  0  0  0  0  3  3  3   4 12 20        2  2  -4 -12 
+Frame20 : B   18   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  3  3   2 10 18        3  3  -2 -6 -14 
+Frame21 : B   17   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  9 17        2  4  -1 -3 -7 -15 
+Frame22 : B   19   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  3 19        2  3  -1 -5 -13 
+Frame23 : B   22   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  3  3   2  6 22        3  3  -2 -10 4
+Frame24 : B   21   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  3   1  5 21        2  3  -1 -3 -11 
+Frame25 : B   23   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  4   1  3  7 23     2  2  -1 -9 
+Frame26 : B   28   3  -5.4095  0.2571  0  0  1.0  0  0  0  0  0  0  3  4  4   4  8 12 28     1  1  -4 
+Frame27 : B   26   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  4  4   2  6 10 26     2  2  -2 -6 
+Frame28 : B   25   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  4   1  5  9 25     2  3  -1 -3 -7 
+Frame29 : B   27   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  4   1  3 11 27     2  2  -1 -5 
+Frame30 : B   30   5  -4.4895  0.1947  0  0  1.0  0  0  0  0  0  0  4  4  4   2  6 14 30     1  1  -2 
+Frame31 : B   29   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  4   1  5 13 29     2  2  -1 -3 
+Frame32 : B   31   6  -5.4429  0.2429  0  0  1.0  0  0  0  0  0  0  5  2  5   1  3  7 15 31  1  1  -1 
+
+#=========== Motion Search =============
+FastSearch                    : 1           # 0:Full search  1:TZ search
+SearchRange                   : 384         # (0: Search range is a Full frame)
+ASR                           : 1           # Adaptive motion search range
+MinSearchWindow               : 96          # Minimum motion search window size for the adaptive window ME
+BipredSearchRange             : 4           # Search range for bi-prediction refinement
+HadamardME                    : 1           # Use of hadamard measure for fractional ME
+FEN                           : 1           # Fast encoder decision
+FDM                           : 1           # Fast Decision for Merge RD cost
+
+#======== Quantization =============
+QP                            : 32          # Quantization parameter(0-51)
+MaxDeltaQP                    : 0           # CU-based multi-QP optimization
+MaxCuDQPSubdiv                : 0           # Maximum subdiv for CU luma Qp adjustment
+DeltaQpRD                     : 0           # Slice-based multi-QP optimization
+RDOQ                          : 1           # RDOQ
+RDOQTS                        : 1           # RDOQ for transform skip
+
+#=========== Deblock Filter ============
+DeblockingFilterOffsetInPPS         : 0           # Dbl params: 0=varying params in SliceHeader, param = base_param + GOP_offset_param; 1 (default) =constant params in PPS, param = base_param)
+DeblockingFilterDisable             : 0           # Disable deblocking filter (0=Filter, 1=No Filter)
+DeblockingFilterBetaOffset_div2     : -2           # base_param: -12 ~ 12
+DeblockingFilterTcOffset_div2       : 0           # base_param: -12 ~ 12
+DeblockingFilterCbBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCbTcOffset_div2     : 0           # base_param: -12 ~ 12
+DeblockingFilterCrBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCrTcOffset_div2     : 0           # base_param: -12 ~ 12
+DeblockingFilterMetric        : 0           # blockiness metric (automatically configures deblocking parameters in bitstream). Applies slice-level loop filter offsets (DeblockingFilterOffsetInPPS and DeblockingFilterDisable must be 0)
+
+#=========== Misc. ============
+InternalBitDepth              : 10          # codec operating bit-depth
+
+#=========== Coding Tools =================
+SAO                           : 1           # Sample adaptive offset  (0: OFF, 1: ON)
+TransformSkip                 : 1           # Transform skipping (0: OFF, 1: ON)
+TransformSkipFast             : 1           # Fast Transform skipping (0: OFF, 1: ON)
+TransformSkipLog2MaxSize      : 5
+SAOLcuBoundary                : 0           # SAOLcuBoundary using non-deblocked pixels (0: OFF, 1: ON)
+
+#============ Rate Control ======================
+RateControl                         : 0                # Rate control: enable rate control
+TargetBitrate                       : 1000000          # Rate control: target bitrate, in bps
+KeepHierarchicalBit                 : 2                # Rate control: 0: equal bit allocation; 1: fixed ratio bit allocation; 2: adaptive ratio bit allocation
+LCULevelRateControl                 : 1                # Rate control: 1: LCU level RC; 0: picture level RC
+RCLCUSeparateModel                  : 1                # Rate control: use LCU level separate R-lambda model
+InitialQP                           : 0                # Rate control: initial QP
+RCForceIntraQP                      : 0                # Rate control: force intra QP to be equal to initial QP
+
+#============ VTM settings ======================
+SEIDecodedPictureHash               : 0
+CbQpOffset                          : 0
+CrQpOffset                          : 0
+SameCQPTablesForAllChroma           : 1
+QpInValCb                           : 17 22 34 42
+QpOutValCb                          : 17 23 35 39
+ReWriteParamSets                    : 1
+#============ NEXT ====================
+
+# General
+CTUSize                      : 128
+LCTUFast                     : 1
+
+DualITree                    : 1      # separate partitioning of luma and chroma channels for I-slices
+MinQTLumaISlice              : 8
+MinQTChromaISliceInChromaSamples: 4      # minimum QT size in chroma samples for chroma separate tree
+MinQTNonISlice               : 8
+MaxMTTHierarchyDepth         : 3
+MaxMTTHierarchyDepthISliceL  : 3
+MaxMTTHierarchyDepthISliceC  : 3
+
+MTS                          : 1
+MTSIntraMaxCand              : 4
+MTSInterMaxCand              : 4
+SBT                          : 1
+LFNST                        : 1
+ISP                          : 1
+MMVD                         : 1
+Affine                       : 1
+SbTMVP                       : 1
+MaxNumMergeCand              : 6
+LMChroma                     : 1      # use CCLM only
+DepQuant                     : 1
+IMV                          : 1
+ALF                          : 1
+BCW                          : 1
+BcwFast                      : 1
+BIO                          : 1
+CIIP                         : 1
+Geo                          : 1
+IBC                          : 0      # turned off in CTC
+AllowDisFracMMVD             : 1
+AffineAmvr                   : 1
+LMCSEnable                   : 1      # LMCS: 0: disable, 1:enable
+LMCSSignalType               : 0      # Input signal type: 0:SDR, 1:HDR-PQ, 2:HDR-HLG
+LMCSUpdateCtrl               : 0      # LMCS model update control: 0:RA, 1:AI, 2:LDB/LDP
+LMCSOffset                   : 6      # chroma residual scaling offset
+MRL                          : 1
+MIP                          : 1
+DMVR                         : 1
+SMVD                         : 1
+JointCbCr                    : 1      # joint coding of chroma residuals (if available): 0: disable, 1: enable
+PROF                         : 1
+
+# Fast tools
+PBIntraFast                  : 1
+ISPFast                      : 0
+FastMrg                      : 1
+AMaxBT                       : 1
+FastMIP                      : 0
+FastLFNST                    : 0
+FastLocalDualTreeMode        : 1
+ChromaTS                     : 1
+
+# Encoder optimization tools
+AffineAmvrEncOpt             : 1
+MmvdDisNum                   : 6
+ALFAllowPredefinedFilters    : 1
+ALFStrengthTargetLuma        : 1.0
+ALFStrengthTargetChroma      : 1.0
+CCALFStrengthTarget          : 1.0
+EncDbOpt                     : 1      # apply deblocking in RDO
+
+TemporalFilter                : 1
+TemporalFilterPastRefs        : 4           # Number of past references for temporal prefilter
+TemporalFilterFutureRefs      : 4           # Number of future references for temporal prefilter
+TemporalFilterStrengthFrame8  : 0.95        # Enable filter at every 8th frame with given strength
+TemporalFilterStrengthFrame16 : 1.5         # Enable filter at every 16th frame with given strength, longer intervals has higher priority
+### DO NOT ADD ANYTHING BELOW THIS LINE ###
+### DO NOT DELETE THE EMPTY LINE BELOW ###
+
+
+

--- a/sshslot.py
+++ b/sshslot.py
@@ -30,7 +30,12 @@ binaries = {
     'thor': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
     'thor-rt': ['build/Thorenc','build/Thordec','config_HDB16_high_efficiency.txt','config_LDB_high_efficiency.txt'],
     'rav1e': ['target/release/rav1e'],
-    'svt-av1': ['Bin/Release/SvtAv1EncApp']
+    'svt-av1': ['Bin/Release/SvtAv1EncApp'],
+    'vvc-vtm': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+    'vvc-vtm-ra': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+    'vvc-vtm-ra-st': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+    'vvc-vtm-ld': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+    'vvc-vtm-ai': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic']
 }
 
 # Finding files such as `this_(that)` requires `'` be placed on both

--- a/work.py
+++ b/work.py
@@ -40,6 +40,11 @@ quality_presets = {
     "thor-rt": list(range(7,43,3)),
     "rav1e": [20*4,32*4,43*4,55*4,63*4],
     "svt-av1": [20,32,43,55,63],
+    "vvc-vtm": [22, 27, 32, 37],
+    "vvc-vtm-ra": [22, 27, 32, 37],
+    "vvc-vtm-ra-st": [22, 27, 32, 37],
+    "vvc-vtm-ld": [22, 27, 32, 37],
+    "vvc-vtm-ai": [22, 27, 32, 37],
 }
 
 class Run:
@@ -294,6 +299,8 @@ def create_rdwork(run, video_filenames):
                     work.copy_back_files.append('.ivf')
                 elif (len(work.codec) >= 3) and (work.codec[0:3] == 'av2'):
                     work.copy_back_files.append('.obu')
+                elif (len(work.codec) >= 3) and (work.codec[0:3] == 'vvc'):
+                    work.copy_back_files.append('.bin')
                 elif work.codec == 'xvc':
                     work.copy_back_files.append('.xvc')
             work_items.append(work)


### PR DESCRIPTION
This PR adds support to encode/decode/compute metrics for VVC-VTM for 
+ RA
+ AI
+ LD
+ RA GOP Parallel

Tested locally with VLC12, the QPs and things are strictly as per JVET_CTC, so it might be incompatible to do apple-apple comparision with AOM/AVM. So we would require to fine-tune the preset options. 