### PR TITLE
server: Avoid re-allocation of prefix

### DIFF
--- a/rd_server.py
+++ b/rd_server.py
@@ -471,9 +471,6 @@ def scheduler_tick():
                     run_tracker[this_run]['done'] = True
                     rd_print(run.log, "Finished Encoding all sets for ", run.runid)
                     try:
-                        # Explicty set the first Task ID as the Prefix for
-                        # average (this taskID is sorted based on priority)
-                        run.prefix = run.rundir + '/' + sorted(run_set_list)[0]
                         # Use A2 set for mandatory/all CTC Class
                         if  'aomctc-mandatory' in run.info['ctcSets'] or 'aomctc-all' in run.info['ctcSets']:
                             run.prefix = run.rundir + '/aomctc-a2-2k'


### PR DESCRIPTION
We are handling them at the server(AWCY) side, so we do not need to touch the prefix, so assume that task is always correct.

