### PR TITLE
metrics_gather: Fix default SVT_AV1 QP assignment

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -462,7 +462,8 @@ svt-av1 | svt-av1-ra | svt-av1-ra-crf | svt-av1-ra-vbr | svt-av1-ra-vbr-2p | svt
       SVT_PROFILE_OPTS="--lp 1 --passes 1 --rc 0 --aq-mode 0 --crf $x --pred-struct 2 --keyint 999"
       ;;
     svt-av1)
-      SVT_PROFILE_OPTS=""
+      # Always define CRF points for the given QPs
+      SVT_PROFILE_OPTS="--crf $x "
       ;;
   esac
   # Encode the video


### PR DESCRIPTION
We are not assigning QPs when no preset is given, this is a regression from 55d1812b4cd466711533f6aae5335872a392b95e