### PR TITLE
Fix Stil Image CTC encodes and copy Encoding/Decoding files

### DIFF
--- a/rd_server.py
+++ b/rd_server.py
@@ -233,8 +233,10 @@ class SubmitTask(SchedulerTask):
                     run.multicfg = True
                 else:
                     run.multicfg = False
-                if this_video_set in ['aomctc-f1-hires','aomctc-f2-midres']:
+                if this_video_set in ['aomctc-f1-hires','aomctc-f2-midres'] and this_preset in ['av2-ai']:
                     run.quality = quality_presets['av2-f']
+                elif this_preset in ['av2-ai']:
+                    run.quality = quality_presets['av2-ai']
                 rd_print(run.log, "Starting encoding of ", this_video_set, "with", this_preset)
                 if 'arch' in info:
                     run.arch = info['arch']
@@ -260,6 +262,9 @@ class SubmitTask(SchedulerTask):
                 if 'save_encode' in info:
                     if info['save_encode']:
                         run.save_encode = True
+                # Explictly signal Limit as 1 for still-images for AV2-AI.
+                if run.set in ['aomctc-f1-hires','aomctc-f2-midres'] and 'av2-ai' in run.codec:
+                    run.extra_options += ' --limit=1 '
                 run.status = 'running'
                 run.write_status()
                 run_list.append(run)

--- a/work.py
+++ b/work.py
@@ -92,7 +92,7 @@ class RDRun(Run):
                 pass
             else:
                 any_work_failed = True
-        subprocess.call('OUTPUT="'+self.prefix+'/'+'total" "'+sys.path[0]+'/rd_average.sh" "'+self.prefix+'/*.out"',
+        subprocess.call('OUTPUT="'+self.prefix+'/'+'total" "'+sys.path[0]+'/rd_average.sh" "'+self.prefix+'/*-daala.out"',
           shell=True)
         if any_work_failed:
             self.status = 'failed'
@@ -121,7 +121,7 @@ class RDWork(Work):
     def __init__(self):
         super().__init__()
         self.no_delete = False
-        self.copy_back_files = ['-stdout.txt']
+        self.copy_back_files = ['-stdout.txt', '-enctime.out', '-dectime.out']
         self.ctc_class = ''
     def parse(self, stdout, stderr):
         self.raw = stdout


### PR DESCRIPTION
Two things
a) Fix still image encoding, as they have different QPs, and have to make sure the limits from CLI is override with --limit=1 else  the Bits will be different

b) Copy back Encoding/Decoding time files, this is mainly useful to track down the encoding/decoding commands for better debugging of a run.
