### PR TITLE
server: Iteratively remove jobs on cancellation and allocate av2-all correctly

### DIFF
--- a/rd_server.py
+++ b/rd_server.py
@@ -215,10 +215,10 @@ class SubmitTask(SchedulerTask):
               run_set_list = [info['task']]
         if len(info['ctcPresets']) > 1:
             run_preset_list = info['ctcPresets']
-            if 'av2-all' in info['ctcPresets']:
-                run_preset_list = ctc_full_presets
         else:
             run_preset_list = [info['codec']]
+        if 'av2-all' in info['ctcPresets']:
+            run_preset_list = ctc_full_presets
         for this_preset in run_preset_list:
             run_set_list = return_set_list(info, this_preset)
             for this_video_set in sorted(run_set_list):
@@ -537,12 +537,12 @@ def scheduler_tick():
                     rd_print(run.log, "Finished Encoding ", run.set, "set for ", run.codec, "config.")
                     run_list.remove(run)
                     run_tracker[this_run]['done'] = False
-                    if len(run.info['ctcSets']) > 1 and len(smtp_config) > 0:
+                    if ((len(run.info['ctcSets']) > 1) or ('aomctc-all' in run.info['ctcSets'])) and len(smtp_config) > 0:
                         submit_email_notification(run, smtp_config, set_flag=True, cfg_flag=False, all_flag=False)
                 if all(value == True for value in run_tracker[this_run]['cfg'][run.codec].values()):
                     rd_print(run.log, "Finished Encoding", run.codec, "config.")
                     run_tracker[this_run]['status'][run.codec] = True
-                    if len(run.info['ctcPresets']) > 1 and len(smtp_config) > 0:
+                    if ((len(run.info['ctcPresets']) > 1) or ('av2-all' in run.info['ctcPresets']))  and len(smtp_config) > 0:
                         submit_email_notification(run, smtp_config, set_flag=False, cfg_flag=True, all_flag=False)
                 if all(value == True for value in run_tracker[this_run]['status'].values()):
                     run_tracker[this_run]['done'] = True
@@ -558,6 +558,8 @@ def scheduler_tick():
                                 run.info['codec'] + '/' + sorted(run_set_list)[0]
                             if 'aomctc-mandatory' in run.info['ctcSets'] or 'aomctc-all' in run.info['ctcSets']:
                                 run.prefix = run.rundir + '/' + run.info['codec'] + '/aomctc-a2-2k'
+                        elif 'av2-all' in run.info['ctcPresets']:
+                            run.prefix = run.rundir + '/' + run.info['codec'] + '/' + run.info['task']
                         run.reduce()
                     except Exception as e:
                         rd_print(run.log,e)

--- a/rd_server.py
+++ b/rd_server.py
@@ -177,6 +177,12 @@ class CancelTask(SchedulerTask):
             rd_print(None,'Could not cancel '+run_id+'. run_id not found.')
             return
         run.cancel()
+        # Explictly search through current runIDs and remove them
+        for this_run in run_list:
+            if this_run.runid == run_id:
+                rd_print(this_run.log, "Cancelling sub-job of",
+                         this_run.set, "for", this_run.codec, ".")
+                this_run.cancel()
         for work in work_list[:]:
             if work.runid == run_id:
                 work_list.remove(work)

--- a/work.py
+++ b/work.py
@@ -121,7 +121,7 @@ class RDWork(Work):
     def __init__(self):
         super().__init__()
         self.no_delete = False
-        self.copy_back_files = ['-stdout.txt', '-enctime.out', '-dectime.out']
+        self.copy_back_files = ['-stdout.txt', '-enctime.out', '-dectime.out', '-encperf.out', '-decperf.out']
         self.ctc_class = ''
     def parse(self, stdout, stderr):
         self.raw = stdout


### PR DESCRIPTION
Make sure we kill all the jobs in the list, since we are having more than one runs for a given run_id due to set and preset nature. 

![image](https://user-images.githubusercontent.com/10833993/209244195-349d852e-ff4f-4927-a7e1-8fed10802b56.png)


This PR also addresses small bug-fix for av2-all allocation which did not work all the time.