### PR TITLE
metrics: Introduce VVC VTM RA CTC

### DIFF
--- a/cfg/vvc-vtm/encoder_randomaccess_vtm_gop16.cfg
+++ b/cfg/vvc-vtm/encoder_randomaccess_vtm_gop16.cfg
@@ -1,0 +1,168 @@
+#======== File I/O =====================
+BitstreamFile                 : str.bin
+ReconFile                     : rec.yuv
+
+#======== Profile ================
+Profile                       : auto
+
+#======== Unit definition ================
+MaxCUWidth                    : 64          # Maximum coding unit width in pixel
+MaxCUHeight                   : 64          # Maximum coding unit height in pixel
+
+#======== Coding Structure =============
+IntraPeriod                   : 32          # Period of I-Frame ( -1 = only first)
+DecodingRefreshType           : 1           # Random Accesss 0:none, 1:CRA, 2:IDR, 3:Recovery Point SEI
+GOPSize                       : 16          # GOP Size (number of B slice = GOPSize-1)
+
+IntraQPOffset                 : -3
+LambdaFromQpEnable            : 1           # see JCTVC-X0038 for suitable parameters for IntraQPOffset, QPoffset, QPOffsetModelOff, QPOffsetModelScale when enabled
+#        Type POC QPoffset QPOffsetModelOff QPOffsetModelScale CbQPoffset CrQPoffset QPfactor tcOffsetDiv2 betaOffsetDiv2 CbTcOffsetDiv2 CbBetaOffsetDiv2 CrTcOffsetDiv2 CrBetaOffsetDiv2 temporal_id #ref_pics_active_L0 #ref_pics_L0   reference_pictures_L0 #ref_pics_active_L1 #ref_pics_L1   reference_pictures_L1
+Frame1:   B   16   1        0.0                      0.0            0          0          1.0      0            0                0             0                0               0              0             2                3          16 32 24                    2                2           16 32
+Frame2:   B    8   1       -4.8848                   0.2061         0          0          1.0      0            0                0             0                0               0              1             2                2          8 16                        2                2           -8 8
+Frame3:   B    4   4       -5.7476                   0.2286         0          0          1.0      0            0                0             0                0               0              2             2                2          4 12                        2                2           -4 -12
+Frame4:   B    2   5       -5.90                     0.2333         0          0          1.0      0            0                0             0                0               0              3             2                2          2 10                        2                3           -2 -6 -14
+Frame5:   B    1   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                2          1 -1                        2                4           -1 -3 -7 -15
+Frame6:   B    3   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                2          1 3                         2                3           -1 -5 -13
+Frame7:   B    6   5       -5.90                     0.2333         0          0          1.0      0            0                0             0                0               0              3             2                2          2 6                         2                2           -2 -10
+Frame8:   B    5   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                2          1 5                         2                3           -1 -3 -11
+Frame9:   B    7   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                3          1 3 7                       2                2           -1 -9
+Frame10:  B   12   4       -5.7476                   0.2286         0          0          1.0      0            0                0             0                0               0              2             2                2          4 12                        2                2           -4 4
+Frame11:  B   10   5       -5.90                     0.2333         0          0          1.0      0            0                0             0                0               0              3             2                2          2 10                        2                2           -2 -6
+Frame12:  B    9   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                2          1 9                         2                3           -1 -3 -7
+Frame13:  B   11   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                3          1 3 11                      2                2           -1 -5
+Frame14:  B   14   5       -5.90                     0.2333         0          0          1.0      0            0                0             0                0               0              3             2                3          2 6 14                      2                2           -2 2
+Frame15:  B   13   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                3          1 5 13                      2                2           -1 -3
+Frame16:  B   15   6       -7.1444                   0.3            0          0          1.0      0            0                0             0                0               0              4             2                4          1 3 7 15                    2                2           -1 1
+
+#=========== Motion Search =============
+FastSearch                    : 1           # 0:Full search  1:TZ search
+SearchRange                   : 384         # (0: Search range is a Full frame)
+ASR                           : 1           # Adaptive motion search range
+MinSearchWindow               : 96          # Minimum motion search window size for the adaptive window ME
+BipredSearchRange             : 4           # Search range for bi-prediction refinement
+HadamardME                    : 1           # Use of hadamard measure for fractional ME
+FEN                           : 1           # Fast encoder decision
+FDM                           : 1           # Fast Decision for Merge RD cost
+
+#======== Quantization =============
+QP                            : 32          # Quantization parameter(0-51)
+MaxDeltaQP                    : 0           # CU-based multi-QP optimization
+MaxCuDQPSubdiv                : 0           # Maximum subdiv for CU luma Qp adjustment
+DeltaQpRD                     : 0           # Slice-based multi-QP optimization
+RDOQ                          : 1           # RDOQ
+RDOQTS                        : 1           # RDOQ for transform skip
+
+#=========== Deblock Filter ============
+DeblockingFilterOffsetInPPS         : 0           # Dbl params: 0=varying params in SliceHeader, param = base_param + GOP_offset_param; 1 (default) =constant params in PPS, param = base_param)
+DeblockingFilterDisable             : 0           # Disable deblocking filter (0=Filter, 1=No Filter)
+DeblockingFilterBetaOffset_div2     : -2           # base_param: -12 ~ 12
+DeblockingFilterTcOffset_div2       : 0           # base_param: -12 ~ 12
+DeblockingFilterCbBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCbTcOffset_div2     : 0           # base_param: -12 ~ 12
+DeblockingFilterCrBetaOffset_div2   : -2           # base_param: -12 ~ 12
+DeblockingFilterCrTcOffset_div2     : 0           # base_param: -12 ~ 12
+DeblockingFilterMetric        : 0           # blockiness metric (automatically configures deblocking parameters in bitstream). Applies slice-level loop filter offsets (DeblockingFilterOffsetInPPS and DeblockingFilterDisable must be 0)
+
+#=========== Misc. ============
+InternalBitDepth              : 10          # codec operating bit-depth
+
+#=========== Coding Tools =================
+SAO                           : 1           # Sample adaptive offset  (0: OFF, 1: ON)
+TransformSkip                 : 1           # Transform skipping (0: OFF, 1: ON)
+TransformSkipFast             : 1           # Fast Transform skipping (0: OFF, 1: ON)
+TransformSkipLog2MaxSize      : 5
+SAOLcuBoundary                : 0           # SAOLcuBoundary using non-deblocked pixels (0: OFF, 1: ON)
+
+#============ Rate Control ======================
+RateControl                         : 0                # Rate control: enable rate control
+TargetBitrate                       : 1000000          # Rate control: target bitrate, in bps
+KeepHierarchicalBit                 : 2                # Rate control: 0: equal bit allocation; 1: fixed ratio bit allocation; 2: adaptive ratio bit allocation
+LCULevelRateControl                 : 1                # Rate control: 1: LCU level RC; 0: picture level RC
+RCLCUSeparateModel                  : 1                # Rate control: use LCU level separate R-lambda model
+InitialQP                           : 0                # Rate control: initial QP
+RCForceIntraQP                      : 0                # Rate control: force intra QP to be equal to initial QP
+
+#============ VTM settings ======================
+SEIDecodedPictureHash               : 0
+CbQpOffset                          : 0
+CrQpOffset                          : 0
+SameCQPTablesForAllChroma           : 1
+QpInValCb                           : 17 22 34 42
+QpOutValCb                          : 17 23 35 39
+ReWriteParamSets                    : 1
+#============ NEXT ====================
+
+# General
+CTUSize                      : 128
+LCTUFast                     : 1
+
+DualITree                    : 1      # separate partitioning of luma and chroma channels for I-slices
+MinQTLumaISlice              : 8
+MinQTChromaISliceInChromaSamples: 4      # minimum QT size in chroma samples for chroma separate tree
+MinQTNonISlice               : 8
+MaxMTTHierarchyDepth         : 3
+MaxMTTHierarchyDepthISliceL  : 3
+MaxMTTHierarchyDepthISliceC  : 3
+
+MTS                          : 1
+MTSIntraMaxCand              : 4
+MTSInterMaxCand              : 4
+SBT                          : 1
+LFNST                        : 1
+ISP                          : 1
+MMVD                         : 1
+Affine                       : 1
+SbTMVP                       : 1
+MaxNumMergeCand              : 6
+LMChroma                     : 1      # use CCLM only
+DepQuant                     : 1
+IMV                          : 1
+ALF                          : 1
+BCW                          : 1
+BcwFast                      : 1
+BIO                          : 1
+CIIP                         : 1
+Geo                          : 1
+IBC                          : 0      # turned off in CTC
+AllowDisFracMMVD             : 1
+AffineAmvr                   : 1
+LMCSEnable                   : 1      # LMCS: 0: disable, 1:enable
+LMCSSignalType               : 0      # Input signal type: 0:SDR, 1:HDR-PQ, 2:HDR-HLG
+LMCSUpdateCtrl               : 0      # LMCS model update control: 0:RA, 1:AI, 2:LDB/LDP
+LMCSOffset                   : 6      # chroma residual scaling offset
+MRL                          : 1
+MIP                          : 1
+DMVR                         : 1
+SMVD                         : 1
+JointCbCr                    : 1      # joint coding of chroma residuals (if available): 0: disable, 1: enable
+PROF                         : 1
+
+# Fast tools
+PBIntraFast                  : 1
+ISPFast                      : 0
+FastMrg                      : 1
+AMaxBT                       : 1
+FastMIP                      : 0
+FastLFNST                    : 0
+FastLocalDualTreeMode        : 1
+ChromaTS                     : 1
+
+# Encoder optimization tools
+AffineAmvrEncOpt             : 1
+MmvdDisNum                   : 6
+ALFAllowPredefinedFilters    : 1
+ALFStrengthTargetLuma        : 1.0
+ALFStrengthTargetChroma      : 1.0
+CCALFStrengthTarget          : 1.0
+EncDbOpt                     : 1      # apply deblocking in RDO
+
+TemporalFilter                : 1
+TemporalFilterPastRefs        : 4           # Number of past references for temporal prefilter
+TemporalFilterFutureRefs      : 4           # Number of future references for temporal prefilter
+TemporalFilterStrengthFrame8  : 0.95        # Enable filter at every 8th frame with given strength
+TemporalFilterStrengthFrame16 : 1.5         # Enable filter at every 16th frame with given strength, longer intervals has higher priority
+### DO NOT ADD ANYTHING BELOW THIS LINE ###
+### DO NOT DELETE THE EMPTY LINE BELOW ###
+
+
+

--- a/sshslot.py
+++ b/sshslot.py
@@ -39,6 +39,7 @@ binaries = {
     "svt-av1-ra-cq": ['Bin/Release/SvtAv1EncApp'],
     'vvc-vtm': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
     'vvc-vtm-ra': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
+    'vvc-vtm-ra-ctc': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
     'vvc-vtm-ra-st': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
     'vvc-vtm-ld': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic'],
     'vvc-vtm-ai': ['bin/EncoderAppStatic', 'bin/DecoderAppStatic', 'bin/parcatStatic']

--- a/work.py
+++ b/work.py
@@ -48,6 +48,7 @@ quality_presets = {
     "svt-av1-ra-cq": [27, 33, 39, 46, 52, 58],
     "vvc-vtm": [22, 27, 32, 37],
     "vvc-vtm-ra": [22, 27, 32, 37],
+    "vvc-vtm-ra-ctc": [22, 27, 32, 37, 42, 47],
     "vvc-vtm-ra-st": [22, 27, 32, 37],
     "vvc-vtm-ld": [22, 27, 32, 37],
     "vvc-vtm-ai": [22, 27, 32, 37],


### PR DESCRIPTION
Introduce a VVC configuration which is close to AOM-CTC's RA configuration, main changes over VVC-CTC-RA
+ Use Parallel GOP by default, as VVC do not allow non-multiple of GopSize for IntraPeriod (we can only do 64, not 65)
+ Use Closed-GOP config, IDR (DecodingRefreshType=2)
+ Use GopSize as 16, encoder_randomaccess_vtm_gop16.cfg
+ Set IntraPeriod as -1, this is for having only 1 I-Frame in every 65 Frames