### PR TITLE
metrics_gather: Introduce Row tiling for A2 and B1 for VVC-VTM-LD

### DIFF
--- a/metrics_gather.sh
+++ b/metrics_gather.sh
@@ -432,6 +432,44 @@ vvc-vtm | vvc-vtm-ra | vvc-vtm-ra-ctc | vvc-vtm-ra-st | vvc-vtm-as-ctc | vvc-vtm
   else
     CTC_PROFILE_OPTS+=" "
   fi
+  # CTCv6:  1. 2x2 tiling for E/G1 in RA
+  #         2. 10bit for A2/A4/B1
+  case $CTC_VERSION in
+    6.0)
+    case $CTC_CLASS in
+      E | G1)
+      case $CODEC in
+        vvc-vtm-ra | vvc-vtm-ra-st | vvc-vtm-ra-ctc)
+          # Manually count the tiles based on MAX_CTU which is currently 128 as
+          # there are vertical videos
+          TILES_W_CNT=$(echo $WIDTH/128 | bc)
+          TILES_H_CNT=$(echo $HEIGHT/128 | bc)
+          CTC_PROFILE_OPTS+=" --EnablePicPartitioning=1 --TileRowHeightArray=${TILES_H_CNT} --TileColumnWidthArray=${TILES_W_CNT}"
+        ;;
+      esac
+      ;;
+      A2 | A4 | B1)
+        CTC_PROFILE_OPTS+="  --InternalBitDepth=10 --InputBitDepth=10"
+      ;;
+      esac
+      ;;
+  esac
+  case $CTC_CLASS in
+    A2 | B1)
+    case $CODEC in
+       vvc-vtm-ld)
+         case $CTC_VERSION in
+          5.0 | 6.0)
+            TILES_W_CNT=$(echo $WIDTH/128 | bc)
+            TILES_H_CNT=$(echo $HEIGHT/128 | bc)
+            CTC_PROFILE_OPTS+=" --EnablePicPartitioning=1 --TileRowHeightArray=${TILES_H_CNT} --TileColumnWidthArray=${TILES_W_CNT}"
+          ;;
+          esac
+    ;;
+    esac
+  ;;
+  esac
+
   # TODO: Remove this hack if the upstream fixes 420mpeg2 handling
   # Reference: https://jvet.hhi.fraunhofer.de/trac/vvc/ticket/1598
   # Convert Y4M to YUV for certain 420mpeg2 videos in VVC

--- a/sets.json
+++ b/sets.json
@@ -1450,6 +1450,39 @@
       "Shaky_Walk_1920x1080_25fps.y4m"
     ]
   },
+  "aomctc-subjective-long":{
+    "type": "video",
+    "sources":[
+      "BarScene_1920x1080_60fps_10bit_420-6s.y4m",
+      "ConferenceBrickWall_1_1920x1080_10bit.y4m",
+      "DrivingPOV3_3840x2160_60fps_10bit_420pf.y4m",
+      "GregoryCactus_fr216_515_1080x1920_30p_420_10b_SDR.y4m",
+      "Marathon2_3840x2160_30fps_10bit_420pf.y4m",
+      "meridian_aom_sdr_11872-12263_3840x2160_5994fps.y4m",
+      "Metro_1920x1080_60fps_10bit_420.y4m",
+      "MountainBay2_3840x2160_30fps_420_10bit.y4m",
+      "Netflix_Meridian2_1920x1080_60fps_10bit_420.y4m",
+      "TallBuildings2_3840x2160_30fps_10bit_420pf.y4m",
+      "YonseiS01_R_00_00_3840x2160p_30fps_10bit.y4m"
+    ],
+    "categories":{
+      "1080p": [
+        "BarScene_1920x1080_60fps_10bit_420-6s.y4m",
+        "ConferenceBrickWall_1_1920x1080_10bit.y4m",
+        "GregoryCactus_fr216_515_1080x1920_30p_420_10b_SDR.y4m",
+        "Metro_1920x1080_60fps_10bit_420.y4m",
+        "Netflix_Meridian2_1920x1080_60fps_10bit_420.y4m"
+      ],
+      "2160p": [
+      "DrivingPOV3_3840x2160_60fps_10bit_420pf.y4m",
+      "Marathon2_3840x2160_30fps_10bit_420pf.y4m",
+      "meridian_aom_sdr_11872-12263_3840x2160_5994fps.y4m",
+      "MountainBay2_3840x2160_30fps_420_10bit.y4m",
+      "TallBuildings2_3840x2160_30fps_10bit_420pf.y4m",
+      "YonseiS01_R_00_00_3840x2160p_30fps_10bit.y4m"
+      ]
+    }
+  },
   "objective-1-fast": {
     "type": "video",
     "categories": {


### PR DESCRIPTION
This adds row-tiling and computes the number of tiles based on MAX_CTU in VVC which is at 128 for LD encodes for A2 and B1.


This is for making VVC-LD encodes compatible with AOM-CTC v4.0 

Tested in VLC12 instance, 
http://vlc12.xiph.osuosl.org:3000/?job=VVC_VTM_20.2_LD_AOM_GOP_TEST_Y4M_V4_WITH_PARALLEL

Sample encode commands,
`/home/xiph/awcy_temp/slot0/vvc-vtm-ld/bin/EncoderAppStatic -i /media/aomctc-b1-syn/CosmosTreeTrunk_sdr_2048x858_25_8bit.y4m -c /home/xiph/awcy_temp/slot0/rd_tool/cfg/vvc-vtm/encoder_lowdelay_vtm.cfg --SourceWidth=2048 --SourceHeight=858 --FrameRate=24.000 --InputBitDepth=8 --IntraPeriod=32 --FramesToBeEncoded=130 --QP=50 --EnablePicPartitioning=1 --TileRowHeightArray=16 -b CosmosTreeTrunk_sdr_2048x858_25_8bit.y4m-50.bin --ReconFile=CosmosTreeTrunk_sdr_2048x858_25_8bit.y4m-50-rec.yuv --FramesToBeEncoded=1':`

For non-A2/B1, 
`/home/xiph/awcy_temp/slot15/vvc-vtm-ld/bin/EncoderAppStatic -i /media/aomctc-e-nonpristine/Noise_AnimationCrayon_1920x1080_2398fps.y4m -c /home/xiph/awcy_temp/slot15/rd_tool/cfg/vvc-vtm/encoder_lowdelay_vtm.cfg --SourceWidth=1920 --SourceHeight=1080 --FrameRate=23.976 --InputBitDepth=8 --IntraPeriod=32 --FramesToBeEncoded=130 --QP=50 -b Noise_AnimationCrayon_1920x1080_2398fps.y4m-50.bin --ReconFile=Noise_AnimationCrayon_1920x1080_2398fps.y4m-50-rec.yuv --FramesToBeEncoded=1"`
