### PR TITLE
Improve Multislot handling

### DIFF
--- a/sshslot.py
+++ b/sshslot.py
@@ -88,7 +88,7 @@ class SlotProcess:
         self.log = log
     def kill(self):
         # wait until there is actually a process to kill
-        success = self.can_kill.wait(20)
+        success = self.can_kill.wait(40)
         if not success:
             rd_print(self.log,"Waited too long for process to kill.")
             if self.p:

--- a/sshslot.py
+++ b/sshslot.py
@@ -116,6 +116,7 @@ class Slot:
         self.work = None
         self.log = log
         self.can_kill = None
+        self.thread_hold = False # Would be useful in future to distinguish between thread holding and other reasons to hold a given slot
     def gather(self):
         return self.p.communicate()
     def start_work(self, work):
@@ -126,6 +127,13 @@ class Slot:
         work_thread.daemon = True
         self.busy = True
         work_thread.start()
+    # Mark a given slot as busy and hold it for parallel processing
+    def hold_work(self, work):
+        self.work = work
+        work.slot = self
+        self.p = SlotProcess(self.log)
+        self.busy = True
+        self.thread_hold = True
     def clear_work(self):
         if self.work:
             self.work.slot = None


### PR DESCRIPTION
This introduces the dynamic allocation of slots for a given job. 

Allocate 1/2 slots based on resolution and job type. 


~Current problem: Slots once removed from free are not allocated at second time. This could be due to a manual rewrite of free_slots.~


Screenshot of machine_usage: 
<img width="737" alt="image" src="https://github.com/xiph/rd_tool/assets/10833993/6a7b8782-91c5-43b4-8942-a17938ae22ef">


Edit:
Motivation: 

Currently many jobs (eg. AVM's RA with >4K resolution), we use multithreaded, and we do not have a clever way to allocate slots to make sure we are not exceeding/throttling machines. We used to have arbitrarily 56 slots on 112 machines (for VLC1,2,3) as a worst-case guess. So it just works. but we are losing a lot of CPU resources. 

This PR introduces a pre-check and allocates one more slot for a job which requires >1 slots

Edit2:
The latest iteration also includes handling of Parallel-GOP jobs, allocating 4 slots in total for 4K resolution jobs. And 2 for <4K Resolution videos. 
